### PR TITLE
Code quality fix - Utility classes should not have public constructors.

### DIFF
--- a/src/org/zoodb/api/ZooConstants.java
+++ b/src/org/zoodb/api/ZooConstants.java
@@ -26,6 +26,8 @@ package org.zoodb.api;
  * @author Tilmann Zaeschke
  */
 public class ZooConstants {
+    
+    private ZooConstants() {}
 
 //	/**
 //	 * Property that defines whether ZooDB should allow second class objects (= embedded objects)

--- a/src/org/zoodb/internal/DataStoreHandler.java
+++ b/src/org/zoodb/internal/DataStoreHandler.java
@@ -25,6 +25,8 @@ import java.util.Properties;
 import org.zoodb.internal.util.DBLogger;
 
 public class DataStoreHandler {
+    
+    private DataStoreHandler() {}
 
 	public static void connect(Properties arg0) {
 		DBLogger.debugPrintln(2, "STUB: DataStoreHandler.connect()");

--- a/src/org/zoodb/internal/query/TypeConverterTools.java
+++ b/src/org/zoodb/internal/query/TypeConverterTools.java
@@ -28,6 +28,8 @@ import org.zoodb.api.impl.ZooPC;
 import org.zoodb.internal.util.DBLogger;
 
 public class TypeConverterTools {
+    
+    private TypeConverterTools() {}
 
 	
 	public static enum COMPARISON_TYPE {

--- a/src/org/zoodb/internal/server/SessionFactory.java
+++ b/src/org/zoodb/internal/server/SessionFactory.java
@@ -37,6 +37,8 @@ import org.zoodb.internal.util.DBLogger;
  * @author Tilmann Zaeschke
  */
 public class SessionFactory {
+    
+    private SessionFactory() {}
 
 	//TODO remove me
 	@Deprecated

--- a/src/org/zoodb/internal/server/index/BitTools.java
+++ b/src/org/zoodb/internal/server/index/BitTools.java
@@ -23,6 +23,8 @@ package org.zoodb.internal.server.index;
 import org.zoodb.api.impl.ZooPC;
 
 public class BitTools {
+    
+    private BitTools() {}
 
 	/** Value to recognize 'null'in indices. Using MIN_VALUE so that NULL is the lowest value
 	 * when sorted. */ 

--- a/src/org/zoodb/internal/server/index/IndexFactory.java
+++ b/src/org/zoodb/internal/server/index/IndexFactory.java
@@ -24,6 +24,8 @@ import org.zoodb.internal.server.DiskIO.PAGE_TYPE;
 import org.zoodb.internal.server.StorageChannel;
 
 public class IndexFactory {
+    
+    private IndexFactory() {}
 
 	/**
 	 * @param type

--- a/src/org/zoodb/internal/util/ClassBuilderSimple.java
+++ b/src/org/zoodb/internal/util/ClassBuilderSimple.java
@@ -3,6 +3,8 @@ package org.zoodb.internal.util;
 import java.nio.ByteBuffer;
 
 public class ClassBuilderSimple {
+    
+    private ClassBuilderSimple() {}
 
 	private static final byte[] BA0_1 = {
 		-54, -2, -70, -66,  // 0-3: magic number 

--- a/src/org/zoodb/internal/util/DBLogger.java
+++ b/src/org/zoodb/internal/util/DBLogger.java
@@ -28,6 +28,8 @@ import org.zoodb.api.ZooException;
 import org.zoodb.api.impl.ZooPC;
 
 public class DBLogger {
+    
+    private DBLogger() {}
 
 	private static final boolean isJDO;
 	//TODO ENUM

--- a/src/org/zoodb/internal/util/DBTracer.java
+++ b/src/org/zoodb/internal/util/DBTracer.java
@@ -31,6 +31,8 @@ import org.zoodb.jdo.ZooJdoHelper;
 import org.zoodb.jdo.ZooJdoProperties;
 
 public class DBTracer {
+    
+    private DBTracer() {}
 
 	/** Create traces? Default is 'false' */
 	public static boolean TRACE = false;

--- a/src/org/zoodb/internal/util/ReflTools.java
+++ b/src/org/zoodb/internal/util/ReflTools.java
@@ -32,6 +32,8 @@ import java.lang.reflect.Method;
  * @author Tilmann Zaeschke
  */
 public class ReflTools {
+    
+    private ReflTools() {}
 
     /**
      * Creates a new instance of the class <tt>cls</tt> using the constructor

--- a/src/org/zoodb/internal/util/Util.java
+++ b/src/org/zoodb/internal/util/Util.java
@@ -23,6 +23,8 @@ package org.zoodb.internal.util;
 import org.zoodb.api.impl.ZooPC;
 
 public class Util {
+    
+    private Util() {}
 
 	public static final String oidToString(Object oid) {
 		Long l = (Long)oid;

--- a/src/org/zoodb/tools/ZooCompareDb.java
+++ b/src/org/zoodb/tools/ZooCompareDb.java
@@ -37,6 +37,8 @@ import org.zoodb.schema.ZooField;
 import org.zoodb.schema.ZooHandle;
 
 public class ZooCompareDb {
+    
+    private ZooCompareDb() {}
 
 	private static boolean logToConsole = false; 
 	private static StringBuilder out;

--- a/src/org/zoodb/tools/ZooConfig.java
+++ b/src/org/zoodb/tools/ZooConfig.java
@@ -1,6 +1,8 @@
 package org.zoodb.tools;
 
 public class ZooConfig {
+    
+    private ZooConfig() {}
 	
 	public static final int MODEL_1P = 1; 
 	public static final int MODEL_2P = 2;

--- a/src/org/zoodb/tools/ZooDebug.java
+++ b/src/org/zoodb/tools/ZooDebug.java
@@ -33,6 +33,8 @@ import org.zoodb.internal.server.SessionFactory;
  *
  */
 public class ZooDebug {
+    
+    private ZooDebug() {}
 
 	//whether this is a test run
 	private static boolean isTesting = false;

--- a/src/org/zoodb/tools/internal/SerializerTools.java
+++ b/src/org/zoodb/tools/internal/SerializerTools.java
@@ -48,6 +48,8 @@ import org.zoodb.internal.SerializerTools.PRIMITIVE;
  * @author Tilmann Zaeschke
  */
 public class SerializerTools {
+    
+    private SerializerTools() {}
 
     // ********************** persistent types enums *******************************
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1118 - Utility classes should not have public constructors.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118
 
Please let me know if you have any questions.

Faisal Hameed