### PR TITLE
Code quality fix -  Case insensitive string comparisons should be made without intermediate upper or lower casing.

### DIFF
--- a/src/org/zoodb/internal/ZooFieldDef.java
+++ b/src/org/zoodb/internal/ZooFieldDef.java
@@ -185,7 +185,7 @@ public class ZooFieldDef {
 
 	private PRIMITIVE getPrimitiveType(String typeName) {
 		for (PRIMITIVE p: PRIMITIVE.values()) {
-			if (p.name().equals(typeName.toUpperCase())) {
+			if (p.name().equalsIgnoreCase(typeName)) {
 				return p;
 			}
 		}

--- a/src/org/zoodb/internal/query/QueryParser.java
+++ b/src/org/zoodb/internal/query/QueryParser.java
@@ -196,7 +196,7 @@ public final class QueryParser {
 			op = LOG_OP.AND;
 		} else if (c == '|' && c2 ==  '|') {
             op = LOG_OP.OR;
-		} else if (substring(pos, pos+10).toUpperCase().equals("PARAMETERS")) {
+		} else if (substring(pos, pos+10).equalsIgnoreCase("PARAMETERS")) {
 			inc(10);
 			trim();
 			parseParameters();
@@ -205,19 +205,19 @@ public final class QueryParser {
 			} else {
 				return new QueryTreeNode(qn1, qt1, null, null, null, negate);
 			}
-		} else if (substring(pos, pos+9).toUpperCase().equals("VARIABLES")) {
+		} else if (substring(pos, pos+9).equalsIgnoreCase("VARIABLES")) {
 			throw new UnsupportedOperationException("JDO feature not supported: VARIABLES");
-		} else if (substring(pos, pos+7).toUpperCase().equals("IMPORTS")) {
+		} else if (substring(pos, pos+7).equalsIgnoreCase("IMPORTS")) {
 			throw new UnsupportedOperationException("JDO feature not supported: IMPORTS");
-		} else if (substring(pos, pos+8).toUpperCase().equals("GROUP BY")) {
+		} else if (substring(pos, pos+8).equalsIgnoreCase("GROUP BY")) {
 			throw new UnsupportedOperationException("JDO feature not supported: GROUP BY");
-		} else if (substring(pos, pos+8).toUpperCase().equals("ORDER BY")) {
+		} else if (substring(pos, pos+8).equalsIgnoreCase("ORDER BY")) {
 			inc(8);
 			parseOrdering(str, pos, order, clsDef);
 			pos = str.length(); //isFinished()!
 			return qn1;
 			//TODO this fails if ORDER BY is NOT the last part of the query...
-		} else if (substring(pos, pos+5).toUpperCase().equals("RANGE")) {
+		} else if (substring(pos, pos+5).equalsIgnoreCase("RANGE")) {
 			throw new UnsupportedOperationException("JDO feature not supported: RANGE");
 		} else {
 			//throw DBLogger.newUser("Unexpected characters: '" + c + c2 + c3 + "' at: " + pos());
@@ -428,11 +428,11 @@ public final class QueryParser {
 				throw DBLogger.newUser("Incompatible types, found number, expected: " +	type);
 			}
 		} else if (type == Boolean.TYPE || type == Boolean.class) {
-			if (substring(pos0, pos0+4).toLowerCase().equals("true") 
+			if (substring(pos0, pos0+4).equalsIgnoreCase("true") 
 					&& (isFinished(4) || charAt(4)==' ' || charAt(4)==')')) {
 				value = true;
 				inc(4);
-			} else if (substring(pos0, pos0+5).toLowerCase().equals("false") 
+			} else if (substring(pos0, pos0+5).equalsIgnoreCase("false") 
 					&& (isFinished(5) || charAt(5)==' ' || charAt(5)==')')) {
 				value = false;
 				inc(5);

--- a/src/org/zoodb/internal/query/QueryParserV2.java
+++ b/src/org/zoodb/internal/query/QueryParserV2.java
@@ -669,7 +669,7 @@ public final class QueryParserV2 {
 			this.str = this.name();
 		}
 		public boolean matches(Token token) {
-			if (token.str != null && token.str.toUpperCase().equals(str)) {
+			if (token.str != null && token.str.equalsIgnoreCase(str)) {
 				return true;
 			}
 			return false;
@@ -886,11 +886,11 @@ public final class QueryParserV2 {
 
 	private Token parseBoolean() {
 		int pos0 = pos();
-		if (substring(pos0, pos0+4).toLowerCase().equals("true") 
+		if (substring(pos0, pos0+4).equalsIgnoreCase("true") 
 				&& (isFinished(4) || isWS(charAt(4)) || charAt(4)==')')) {
 			inc(4);
 			return new Token(T_TYPE.TRUE, pos0);
-		} else if (substring(pos0, pos0+5).toLowerCase().equals("false") 
+		} else if (substring(pos0, pos0+5).equalsIgnoreCase("false") 
 				&& (isFinished(5) || isWS(charAt(5)) || charAt(5)==')')) {
 			inc(5);
 			return new Token(T_TYPE.FALSE, pos0);
@@ -900,7 +900,7 @@ public final class QueryParserV2 {
 	
 	private Token parseNull() {
 		int pos0 = pos();
-		if (substring(pos0, pos0+4).toLowerCase().equals("null") 
+		if (substring(pos0, pos0+4).equalsIgnoreCase("null") 
 				&& (isFinished(4) || isWS(charAt(4)) || charAt(4)==')')) {
 			inc(4);
 			return new Token(T_TYPE.NULL, pos0);

--- a/src/org/zoodb/jdo/impl/QueryImpl.java
+++ b/src/org/zoodb/jdo/impl/QueryImpl.java
@@ -150,14 +150,14 @@ public class QueryImpl implements Query {
 		String tok = st.nextToken();
 
 		//SELECT
-		if (!tok.toLowerCase().equals("select")) {
+		if (!tok.equalsIgnoreCase("select")) {
 			throw new JDOUserException("Illegal token in query: \"" + tok + "\"");
 		}
 		q = q.substring(6).trim();
 		tok = st.nextToken();
 
 		//UNIQUE
-		if (tok.toLowerCase().equals("unique")) {
+		if (tok.equalsIgnoreCase("unique")) {
 			unique = true;
 			q = q.substring(6).trim();
 			tok = st.nextToken();
@@ -165,7 +165,7 @@ public class QueryImpl implements Query {
 
 		//INTO
 		//TODO
-		if (tok.toLowerCase().equals("into")) {
+		if (tok.equalsIgnoreCase("into")) {
 			//			_unique = true;
 			//			q = q.substring(4).trim();
 			//			tok = getToken(q);
@@ -173,7 +173,7 @@ public class QueryImpl implements Query {
 		}
 
 		//FROM
-		if (tok.toLowerCase().equals("from")) {
+		if (tok.equalsIgnoreCase("from")) {
 			q = q.substring(4).trim();
 			tok = st.nextToken();
 			setClass( locateClass(tok) );
@@ -184,10 +184,10 @@ public class QueryImpl implements Query {
 			tok = st.nextToken();
 
 			//EXCLUDE SUBCLASSES
-			if (tok.toLowerCase().equals("exclude")) {
+			if (tok.equalsIgnoreCase("exclude")) {
 				q = q.substring(7).trim();
 				tok = st.nextToken();
-				if (!tok.toLowerCase().equals("subclasses")) {
+				if (!tok.equalsIgnoreCase("subclasses")) {
 					throw new JDOUserException("Illegal token in query, expected 'SUBCLASSES': \"" + 
 							tok + "\"");
 				}
@@ -198,13 +198,13 @@ public class QueryImpl implements Query {
 		}
 
 		//WHERE
-		if (tok.toLowerCase().equals("where")) {
+		if (tok.equalsIgnoreCase("where")) {
 			q = q.substring(5).trim();
 			this.filter = q;
 			//TODO
 		} else {
 		    //maybe the query is finished?
-		    if (!tok.toLowerCase().equals("")) {
+		    if (!tok.equalsIgnoreCase("")) {
 		        throw new JDOUserException("Illegal token in query, expected 'WHERE': \"" + tok + 
 		                "\"");
 		    }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1157 - Case insensitive string comparisons should be made without intermediate upper or lower casing.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1157

Please let me know if you have any questions.

Faisal Hameed
